### PR TITLE
Fix prod deploy: switch to built-in GITHUB_TOKEN

### DIFF
--- a/.github/workflows/prod.js.yml
+++ b/.github/workflows/prod.js.yml
@@ -12,6 +12,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     strategy:
       matrix:
         node-version: [26.x]
@@ -40,12 +43,7 @@ jobs:
 
     - name: Deploy
       run: |
-        git config --global user.name $user_name
-        git config --global user.email $user_email
-        git remote set-url origin https://${github_token}@github.com/${repository}
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
         npm run deploy
-      env:
-        user_name: 'github-actions[bot]'
-        user_email: 'github-actions[bot]@users.noreply.github.com'
-        github_token: ${{ secrets.ACTIONS_DEPLOY_ACCESS_TOKEN }}
-        repository: ${{ github.repository }}


### PR DESCRIPTION
Replace ACTIONS_DEPLOY_ACCESS_TOKEN (custom PAT that expires) with the built-in GITHUB_TOKEN. Add permissions: contents: write so the job can push to the gh-pages branch. Uses x-access-token auth format expected by gh-pages. No manual secret rotation needed going forward.

https://claude.ai/code/session_01QUadFhsGJUYLSB6KRkwbv4